### PR TITLE
Implement missing methods so that this compiles without errors

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Containers/AdminInventory.java
+++ b/src/main/java/com/Acrobot/ChestShop/Containers/AdminInventory.java
@@ -68,6 +68,16 @@ public class AdminInventory implements Inventory {
     }
 
     @Override
+    public ItemStack[] getStorageContents() {
+        return new ItemStack[0];
+    }
+
+    @Override
+    public void setStorageContents(ItemStack[] itemStacks) throws IllegalArgumentException {
+
+    }
+
+    @Override
     public boolean contains(int i) {
         return true;
     }


### PR DESCRIPTION
To fix the following error when building with Apache Maven:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:compile (default-compile) on project chestshop: Compilation failure
[ERROR] /home/brian/IdeaProjects/ChestShop-3/src/main/java/com/Acrobot/ChestShop/Containers/AdminInventory.java:[19,7] error: AdminInventory is not abstract and does not override abstract method setStorageContents(ItemStack[]) in Inventory
```

The methods themselves do nothing, my presumption being that they aren't actually required.
