### PR TITLE
Metrics R8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.mcstats.bukkit</groupId>
             <artifactId>metrics</artifactId>
-            <version>R7</version>
+            <version>R8-SNAPSHOT</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Metrics should be updated because R7 uses `Player[] getOnlinePlayers()` which is absent on latest Spigot, but R8-SNAPSHOT uses `Collection<Player> getOnlinePlayers()`.
