### PR TITLE
Few 'Quality of Life' improvements.

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/ChestShop.java
+++ b/src/main/java/com/Acrobot/ChestShop/ChestShop.java
@@ -38,6 +38,15 @@ import com.Acrobot.ChestShop.Signs.RestrictedSign;
 import com.Acrobot.ChestShop.UUIDs.NameManager;
 import com.Acrobot.ChestShop.Updater.Updater;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.filter.AbstractFilter;
+import org.apache.logging.log4j.message.Message;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -82,6 +91,7 @@ public class ChestShop extends JavaPlugin {
         Configuration.pairFileAndClass(loadFile("config.yml"), Properties.class);
         Configuration.pairFileAndClass(loadFile("local.yml"), Messages.class);
 
+        turnOffDatabaseLogging();
         handleMigrations();
 
         itemDatabase = new ItemDatabase();
@@ -113,6 +123,46 @@ public class ChestShop extends JavaPlugin {
 
         startStatistics();
         startUpdater();
+    }
+
+    private void turnOffDatabaseLogging() {
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        org.apache.logging.log4j.core.config.Configuration config = ctx.getConfiguration();
+        LoggerConfig loggerConfig = config.getLoggerConfig("");
+
+        loggerConfig.addFilter(new AbstractFilter() {
+            @Override
+            public Result filter(org.apache.logging.log4j.core.Logger logger, Level level, Marker marker, String msg, Object... params) {
+                return filter(logger.getName(), level);
+            }
+
+            @Override
+            public Result filter(org.apache.logging.log4j.core.Logger logger, Level level, Marker marker, Object msg, Throwable t) {
+                return filter(logger.getName(), level);
+            }
+
+            @Override
+            public Result filter(org.apache.logging.log4j.core.Logger logger, Level level, Marker marker, Message msg, Throwable t) {
+                return filter(logger.getName(), level);
+            }
+
+            @Override
+            public Result filter(LogEvent event) {
+                return filter(event.getLoggerName(), event.getLevel());
+            }
+
+            private Result filter(String classname, Level level) {
+                if (level.isAtLeastAsSpecificAs(Level.ERROR) && !classname.contains("SqliteDatabaseType")) {
+                    return Result.NEUTRAL;
+                }
+
+                if (classname.contains("SqliteDatabaseType") || classname.contains("TableUtils")) {
+                    return Result.DENY;
+                } else {
+                    return Result.NEUTRAL;
+                }
+            }
+        });
     }
 
     private void handleMigrations() {

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Block/Break/SignBreak.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Block/Break/SignBreak.java
@@ -63,6 +63,9 @@ public class SignBreak implements Listener {
     public static void onSignBreak(BlockBreakEvent event) {
         if (!canBlockBeBroken(event.getBlock(), event.getPlayer())) {
             event.setCancelled(true);
+            if (isSign(event.getBlock())) {
+                event.getBlock().getState().update();
+            }
         }
     }
 
@@ -118,7 +121,6 @@ public class SignBreak implements Listener {
         boolean canBeBroken = true;
 
         for (Sign sign : attachedSigns) {
-            sign.update();
 
             if (!canBeBroken || !ChestShopSign.isValid(sign)) {
                 continue;

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Player/PlayerConnect.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Player/PlayerConnect.java
@@ -27,18 +27,6 @@ public class PlayerConnect implements Listener {
                 String playerName = NameUtil.stripUsername(playerDTO.getName());
                 UUID uuid = NameManager.getUUID(playerName);
 
-                if (uuid != null && !playerDTO.getUniqueId().equals(uuid)) {
-                    Bukkit.getScheduler().runTask(ChestShop.getPlugin(), new Runnable() {
-                        @Override
-                        public void run() {
-                            Bukkit.getPlayer(playerDTO.getUniqueId()).kickPlayer("[ChestShop]" +
-                                    "Unfortunately, this username was already used by " +
-                                    "another player.");
-
-                        }
-                    });
-                }
-
                 NameManager.storeUsername(playerDTO);
             }
         });


### PR DESCRIPTION
> Move sign-update() to break listener
> 
> This fixes an infinite loop crash where the sign update calls the piston event and the update again and again.
> Also signs can't even be pushed by pistons...

Credits to @Phoenix616 for this fix.

---

> Revert PlayerKick Behavior
> 
> Partial revert of 'Do not let people with already used usernames connect to the server' commit. 
> 
> See comments here Acrobot@b0369d8#commitcomment-14185778 and here. 
> Acrobot@c169df2#commitcomment-12846919
> 
> I personally believe ChestShops should not dictate whether a player is allowed to connect to the server or not. I personally have had issues with ChestShops kicking legitimate players from the server in online mode.

---

> Re-add database suppression.
> 
> Re-add database suppression for SQLite driver start-up log warnings.
> 
> https://dev.bukkit.org/bukkit-plugins/chestshop/tickets/1059-warning-you-seem-to-not-be-using-the-xerial-sqlite/
> https://dev.bukkit.org/bukkit-plugins/chestshop/tickets/1086-error-com-acrobot-chest-shop-ormlite-db-sqlite-database/
